### PR TITLE
Server: add controlled shutdown support and clean status server stop

### DIFF
--- a/cmd/connet/main.go
+++ b/cmd/connet/main.go
@@ -273,8 +273,15 @@ func runWithStatus[T any](ctx context.Context, srv withStatus[T], statusAddr *ne
 		return srv.Run(ctx)
 	}
 
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
 	g := reliable.NewGroup(ctx)
-	g.Go(srv.Run)
+	g.Go(func(ctx context.Context) error {
+		err := srv.Run(ctx)
+		cancel()
+		return err
+	})
 	g.Go(func(ctx context.Context) error {
 		logger.Debug("running status server", "addr", statusAddr)
 		return statusc.Run(ctx, statusAddr, srv.Status)

--- a/pkg/statusc/server.go
+++ b/pkg/statusc/server.go
@@ -39,5 +39,9 @@ func Run[T any](ctx context.Context, addr *net.TCPAddr, f func(ctx context.Conte
 		}
 	}()
 
-	return srv.ListenAndServe()
+	err := srv.ListenAndServe()
+	if err == http.ErrServerClosed {
+		return nil
+	}
+	return err
 }

--- a/server/server.go
+++ b/server/server.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net"
 	"path/filepath"
+	"sync"
 
 	"github.com/connet-dev/connet/pkg/certc"
 	"github.com/connet-dev/connet/pkg/netc"
@@ -20,6 +21,9 @@ type Server struct {
 
 	control *control.Server
 	relay   *relay.Server
+
+	shutdownMu sync.Mutex
+	shutdown   context.CancelFunc
 }
 
 func New(opts ...Option) (*Server, error) {
@@ -102,10 +106,28 @@ func New(opts ...Option) (*Server, error) {
 }
 
 func (s *Server) Run(ctx context.Context) error {
+	ctx, cancel := context.WithCancel(ctx)
+	s.shutdownMu.Lock()
+	s.shutdown = cancel
+	s.shutdownMu.Unlock()
+	defer func() {
+		s.shutdownMu.Lock()
+		s.shutdown = nil
+		s.shutdownMu.Unlock()
+	}()
+
 	g := reliable.NewGroup(ctx)
 	g.Go(s.control.Run)
 	g.Go(s.relay.Run)
 	return g.Wait()
+}
+
+func (s *Server) Shutdown() {
+	s.shutdownMu.Lock()
+	defer s.shutdownMu.Unlock()
+	if s.shutdown != nil {
+		s.shutdown()
+	}
 }
 
 func (s *Server) Status(ctx context.Context) (ServerStatus, error) {


### PR DESCRIPTION
- moved `Server.Run` to its own `context.WithCancel`
- added `Server.Shutdown()`
- updated `runWithStatus` so the status server closes when the main server closes
- ignoring `http.ErrServerClosed` in **pkg/statusc/server.go**